### PR TITLE
Fix condify_name to always return full requirement

### DIFF
--- a/setuptools_conda/setuptools_conda.py
+++ b/setuptools_conda/setuptools_conda.py
@@ -65,7 +65,7 @@ def split(s, delimiter=','):
 def condify_name(requirement, name_replacements=None):
     """Given a requirement such as 'foo >= 6' (with no environment markers), replace the
     package name with its entry, if any, in the dict name_replacements, otherwise make
-    th package name lowercase and replace, underscores with hyphens."""
+    the package name lowercase and replace, underscores with hyphens."""
     if name_replacements is None:
         name_replacements = {}
     splitchars = ' <>=!'
@@ -75,7 +75,8 @@ def condify_name(requirement, name_replacements=None):
     if name in name_replacements:
         return requirement.replace(name, name_replacements[name])
     else:
-        return name.lower().replace('_', '-')
+        return requirement.replace(name, name.lower().replace("_", "-"))
+
 
 def condify_requirements(requires, name_replacements):
     """Convert requirements in the format of `setuptools.Distribution.install_requires`


### PR DESCRIPTION
@chrisjbillington 

Previously, in the case where there were no name replacements, only the name itself was being returned and not the full requirement which is what is expected in both cases. Because of this, published packages included the dependencies but not any of the version info from `install_requires`. A minimal recreation of this issue can be seen below

```python
In [1]: from setuptools_conda.setuptools_conda import condify_name

In [2]: condify_name("python-dateutil>=2.8")
Out[2]: 'python-dateutil'

In [3]: condify_name("python-dateutil>=2.8", name_replacements={"python-dateutil": "python-dateutil"})
Out[3]: 'python-dateutil>=2.8'
```

You will note in the above example that `condify_name("python-dateutil>=2.8")` drops the version info in the returned string. However, including `name_replacements`(even replace name with itself as I did above) returns the full requirement including the version info which I believe is the intended behavior. Once I made the change in this repo, `condify_name("python-dateutil>=2.8")` returned the expected result of `'python-dateutil>=2.8'`.

I further tested this locally by building my package with the current code and getting the dependencies(using `conda search --info -c file://<path to package dir> <package name>`) and it showed the following.

```
dependencies:
  - alembic
  - boto3
  - promise
  - psycopg2
  - python >=3.8,<3.9.0a0
  - python-dateutil
  - python_abi 3.8.* *_cp38
  - s3fs
  - sqlalchemy
```

I then made the change in this PR, built, and gathered info again which yielded the following showing that the requirements now included version info as expected.

```
dependencies:
  - alembic >=1.4.0
  - boto3 >=1.9
  - promise >=2.2
  - psycopg2 >=2.8
  - python >=3.8,<3.9.0a0
  - python-dateutil >=2.8
  - python_abi 3.8.* *_cp38
  - s3fs <0.5
  - sqlalchemy <2,>=1.3.17
 ```
 
 I didn't see any unit tests in the repo(please refer me to them if I missed them) so hopefully the testing above will suffice.