### PR TITLE
Avoid NoneType error in `entries`

### DIFF
--- a/setuptools_conda/setuptools_conda.py
+++ b/setuptools_conda/setuptools_conda.py
@@ -303,7 +303,7 @@ def evaluate_requirements(entries):
     """Evaluate env markers and return a list of the requirements that are needed in the
     current environment required"""
     requirements = []
-    for entry in entries:
+    for entry in entries or []:
         entry = entry.replace(" ", "")
         if not entry:
             continue


### PR DESCRIPTION
@chrisjbillington, currently setuptools-conda fails when building the `timm` pypi package. You can see the error and stack-trace here:

https://github.com/fastai/fastconda/runs/6120387984?check_suite_focus=true

This PR fixes the issue, which comes from assuming that `entries` is iterable.