### PR TITLE
Add option to over-ride license metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Options for 'dist_conda' command:
                             `command_options`. Defaults to the current Python
                             version.
   --build-number (-n)       Conda build number. Defaults to zero
+  --license                 Manually specify the type of license for the conda
+                            package. Defaults to the license defined in the 
+                            package metadata.
   --license-file (-l)       License file to include in the conda package.
                             Defaults to any file in the working directory
                             named 'LICENSE', 'COPYING', or 'COPYRIGHT', case

--- a/setuptools_conda/setuptools_conda.py
+++ b/setuptools_conda/setuptools_conda.py
@@ -331,6 +331,16 @@ class dist_conda(Command):
         ),
         ('build-number=', 'n', "Conda build number. Defaults to zero"),
         (
+            'license=',
+            None,
+            dedent(
+                """
+                Manually specify the type of license for the conda package.
+                Defaults to the license defined in the package metadata.
+                """
+            )
+        ),
+        (
             'license-file=',
             'l',
             dedent(
@@ -494,6 +504,7 @@ class dist_conda(Command):
         self.ignore_run_exports = []
         self.channels = None
         self.HOME = self.distribution.get_url()
+        self.license = None
         self.LICENSE = self.distribution.get_license()
         self.SUMMARY = self.distribution.get_description()
 
@@ -518,6 +529,9 @@ class dist_conda(Command):
         self.croot = None
 
     def finalize_options(self):
+        if self.license is not None:
+            # use license over-ride
+            self.LICENSE = self.license
         if self.license_file is None:
             msg = """No file called LICENSE, COPYING or COPYRIGHT with any extension
                 found"""


### PR DESCRIPTION
This PR fixes #19, providing a build argument that allows for manually specifying the license type in the metadata of the recipe.

