### PR TITLE
Enable osx-arm64 builds

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -56,7 +56,7 @@ jobs:
         run: git tag -d $(git tag --points-at HEAD)
 
       - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,10 +25,14 @@ jobs:
           - { os: ubuntu-latest,   python: '3.9',  arch: x64 }
           - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
 
-          - { os: macos-11,    python: '3.11',  arch: x64 }
-          - { os: macos-11,    python: '3.10',  arch: x64 }
-          - { os: macos-11,    python: '3.9',  arch: x64 }
-          - { os: macos-11,    python: '3.8',  arch: x64 }
+          - { os: macos-latest,    python: '3.11',  arch: x64 }
+          - { os: macos-latest,    python: '3.10',  arch: x64 }
+          - { os: macos-latest,    python: '3.9',  arch: x64 }
+          - { os: macos-latest,    python: '3.8',  arch: x64 }
+
+          - { os: macos-latest,    python: '3.11',  arch: arm64 }
+          - { os: macos-latest,    python: '3.10',  arch: arm64 }
+          - { os: macos-latest,    python: '3.9',  arch: arm64 }
 
           - { os: windows-latest,  python: '3.11',  arch: x64 }
           - { os: windows-latest,  python: '3.10',  arch: x64 }

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -30,9 +30,9 @@ jobs:
           - { os: macos-latest,    python: '3.9',  arch: x64 }
           - { os: macos-latest,    python: '3.8',  arch: x64 }
 
-          - { os: macos-latest,    python: '3.11',  arch: arm64 }
-          - { os: macos-latest,    python: '3.10',  arch: arm64 }
-          - { os: macos-latest,    python: '3.9',  arch: arm64 }
+          - { os: macos-14,    python: '3.11',  arch: arm64 }
+          - { os: macos-14,    python: '3.10',  arch: arm64 }
+          - { os: macos-14,    python: '3.9',  arch: arm64 }
 
           - { os: windows-latest,  python: '3.11',  arch: x64 }
           - { os: windows-latest,  python: '3.10',  arch: x64 }

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,14 +25,14 @@ jobs:
           - { os: ubuntu-latest,   python: '3.9',  arch: x64 }
           - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
 
-          - { os: macos-latest,    python: '3.11',  arch: x64 }
-          - { os: macos-latest,    python: '3.10',  arch: x64 }
-          - { os: macos-latest,    python: '3.9',  arch: x64 }
-          - { os: macos-latest,    python: '3.8',  arch: x64 }
+          - { os: macos-13,        python: '3.11',  arch: x64 }
+          - { os: macos-13,        python: '3.10',  arch: x64 }
+          - { os: macos-13,        python: '3.9',  arch: x64 }
+          - { os: macos-13,        python: '3.8',  arch: x64 }
 
-          - { os: macos-14,    python: '3.11',  arch: arm64 }
-          - { os: macos-14,    python: '3.10',  arch: arm64 }
-          - { os: macos-14,    python: '3.9',  arch: arm64 }
+          - { os: macos-latest,    python: '3.11',  arch: arm64 }
+          - { os: macos-latest,    python: '3.10',  arch: arm64 }
+          - { os: macos-latest,    python: '3.9',  arch: arm64 }
 
           - { os: windows-latest,  python: '3.11',  arch: x64 }
           - { os: windows-latest,  python: '3.10',  arch: x64 }


### PR DESCRIPTION
I was looking to add osx-arm64 builds now that github has the `macos-14` runners available and apparently they ([very recently](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)) made the arm64 runner the default runner for `macos-latest` and are deprecating the `macos-11` runner in June.

This PR attempts to move all macos builds to the `macos-latest` label and does builds for x86-64 and arm64 architectures.

Fixes #17 

Note: I have not actually tested this workflow anywhere. Hopefully it works as simply as it claims.