### PR TITLE
Fix built package finding for `conda-build>=25`

### DIFF
--- a/setuptools_conda/setuptools_conda.py
+++ b/setuptools_conda/setuptools_conda.py
@@ -768,7 +768,12 @@ class dist_conda(Command):
 
         repodir = os.path.join(self.croot, platform)
         with open(os.path.join(repodir, 'repodata.json')) as f:
-            pkgs = [os.path.join(repodir, pkg) for pkg in json.load(f)["packages"]]
+            repodata = json.load(f)
+            if repodata["packages"]:
+                pkgsd = repodata["packages"]
+            else:
+                pkgsd = repodata["packages.conda"]  # conda-build>=25 default behavior
+            pkgs = [os.path.join(repodir, pkg) for pkg in pkgsd]
 
         if not os.path.exists(self.DIST_DIR):
             os.mkdir(self.DIST_DIR)


### PR DESCRIPTION
New behavior is to produce files with `.conda` suffix and have them listed in the `packages.conda` entry of the `repodata.json` file.

Fixes #24 